### PR TITLE
PXP-2537 Update PPCP in express pay library to use tax and shipping e…

### DIFF
--- a/src/types/apiInterfaces.ts
+++ b/src/types/apiInterfaces.ts
@@ -394,6 +394,7 @@ export interface IOrderInitialData {
     life_elements: Array<ILifeField>;
     flow_settings: Record<string, unknown>;
     requires_shipping: boolean;
+    rsa_enabled: boolean;
 }
 
 export interface ISupportedLanguage {

--- a/src/variables/mocks.ts
+++ b/src/variables/mocks.ts
@@ -355,6 +355,7 @@ export const orderInitialDataMock: IOrderInitialData = {
     life_elements: [],
     flow_settings: {},
     requires_shipping: true,
+    rsa_enabled: false,
 };
 
 export const cssRuleMock: ICssRule = {

--- a/src/variables/variables.ts
+++ b/src/variables/variables.ts
@@ -204,6 +204,7 @@ export const orderInitialData: IOrderInitialData = {
     life_elements: [],
     flow_settings: {},
     requires_shipping: true,
+    rsa_enabled: false,
 };
 
 export const retryErrorCodeList: Array<number> = [


### PR DESCRIPTION
…stimates

* Update to add rsa_enabled to the order init object
* Required to implement estimates in express pay library
* Updated variable interface and mock

Required for this PR https://github.com/bold-commerce/checkout-express-pay-library/pull/15

PR not required, turns out the value I needed was elsewhere in the library