### PR TITLE
INTER-3509-Add hide-credit-card-payment-option action

### DIFF
--- a/src/pigi/index.ts
+++ b/src/pigi/index.ts
@@ -4,6 +4,7 @@ export * from './sendAddPaymentAction';
 export * from './sendClearErrorMessageAction';
 export * from './sendDisplayErrorMessageAction';
 export * from './sendHandleScaAction';
+export * from './sendHideCreditCardOptionAction';
 export * from './sendRefreshOrderAction';
 export * from './sendSelectPaymentMethodAction';
 export * from './sendUpdateLanguageAction';

--- a/src/pigi/sendHideCreditCardOptionAction.ts
+++ b/src/pigi/sendHideCreditCardOptionAction.ts
@@ -1,0 +1,24 @@
+import {pigiActionTypes, IApiReturnObject, IPigiActionType, IPigiResponseType, sendPigiAction, sendPigiActionAsync} from 'src';
+
+const action: IPigiActionType = { actionType: pigiActionTypes.PIGI_HIDE_CREDIT_CARD_OPTION };
+/**
+ * ## sendHideCreditCardOptionAction
+ *
+ * This action is to be sent after PIGI has been loaded. It causes the credit card
+ * fields in PIGI to be hidden.
+ */
+export function sendHideCreditCardOptionAction(): IApiReturnObject {
+    return sendPigiAction(action);
+}
+
+/**
+ * ## sendHideCreditCardOptionActionAsync
+ *
+ * This action is to be sent after PIGI has been loaded. It causes the credit card
+ * fields in PIGI to be hidden.
+ *
+ * This method waits for a response back from PIGI before returning.
+ */
+export async function sendHideCreditCardOptionActionAsync(): Promise<IPigiResponseType> {
+    return await sendPigiActionAsync(action);
+}

--- a/src/types/apiInterfaces.ts
+++ b/src/types/apiInterfaces.ts
@@ -78,6 +78,7 @@ export interface IPigiActionTypes {
     PIGI_PAYMENT_ADDED: string;
     PIGI_DISPLAY_IN_FULL_PAGE: string;
     PIGI_DISPLAY_IN_FULL_PAGE_DONE: string;
+    PIGI_HIDE_CREDIT_CARD_OPTION: string;
 }
 
 export interface IExternalPaymentGatewayToParentActionTypes {

--- a/src/variables/constants.ts
+++ b/src/variables/constants.ts
@@ -67,6 +67,7 @@ export const pigiActionTypes: IPigiActionTypes = {
     PIGI_PAYMENT_ADDED: 'PIGI_PAYMENT_ADDED',
     PIGI_DISPLAY_IN_FULL_PAGE: 'PIGI_DISPLAY_IN_FULL_PAGE',
     PIGI_DISPLAY_IN_FULL_PAGE_DONE: 'PIGI_DISPLAY_IN_FULL_PAGE_DONE',
+    PIGI_HIDE_CREDIT_CARD_OPTION: 'PIGI_HIDE_CREDIT_CARD_OPTION',
 };
 
 export const externalPaymentGatewayToParentActionTypes: IExternalPaymentGatewayToParentActionTypes = {

--- a/tests/pigi/sendHideCreditCardOptionAction.test.ts
+++ b/tests/pigi/sendHideCreditCardOptionAction.test.ts
@@ -1,0 +1,59 @@
+import {apiErrors, baseReturnObject, pigiActionTypes, FetchError, IPigiResponseType, sendHideCreditCardOptionAction, sendHideCreditCardOptionActionAsync} from 'src';
+import {pigi} from 'src/variables';
+import * as sendPigiAction from 'src/pigi/sendPigiAction';
+
+describe('testing send PIGI Hide Credit Card Action', () => {
+    pigi.iFrameId = 'PIGI';
+    const calledOnce = 1;
+    let sendPigiActionSpy: jest.SpyInstance;
+    let sendPigiActionAsyncSpy: jest.SpyInstance;
+    const expectedAction = { actionType: pigiActionTypes.PIGI_HIDE_CREDIT_CARD_OPTION };
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        sendPigiActionSpy = jest.spyOn(sendPigiAction, 'sendPigiAction');
+        sendPigiActionAsyncSpy = jest.spyOn(sendPigiAction, 'sendPigiActionAsync');
+    });
+
+    test('calling sendAddPaymentAction success', () => {
+        const tempReturnObject = {...baseReturnObject};
+        tempReturnObject.success = true;
+        sendPigiActionSpy.mockReturnValueOnce(tempReturnObject);
+
+        const res = sendHideCreditCardOptionAction();
+
+        expect(sendPigiActionSpy).toHaveBeenCalledTimes(calledOnce);
+        expect(sendPigiActionSpy).toHaveBeenCalledWith(expectedAction);
+        expect(res).not.toBeNull();
+        expect(res).toStrictEqual(tempReturnObject);
+    });
+
+    test('calling sendHideCreditCardOptionAction null Frame Window', () => {
+        const tempReturnObject = {...baseReturnObject};
+        tempReturnObject.success = false;
+        tempReturnObject.error = new FetchError(apiErrors.noPigiIframe.status, apiErrors.noPigiIframe.message);
+        sendPigiActionSpy.mockReturnValueOnce(tempReturnObject);
+
+        const res = sendHideCreditCardOptionAction();
+
+        expect(sendPigiActionSpy).toHaveBeenCalledTimes(calledOnce);
+        expect(res).not.toBeNull();
+        expect(res).toStrictEqual(tempReturnObject);
+    });
+
+    test('calling sendAddPaymentActionAsync success', async () => {
+        const tempReturnObject: IPigiResponseType = {
+            responseType: pigiActionTypes.PIGI_HIDE_CREDIT_CARD_OPTION,
+            payload: {success: true}
+        };
+        sendPigiActionAsyncSpy.mockReturnValueOnce(tempReturnObject);
+
+        const res = await sendHideCreditCardOptionActionAsync();
+
+        expect(sendPigiActionAsyncSpy).toHaveBeenCalledTimes(calledOnce);
+        expect(sendPigiActionAsyncSpy).toHaveBeenCalledWith(expectedAction);
+        expect(res).not.toBeNull();
+        expect(res).toStrictEqual(tempReturnObject);
+    });
+});
+


### PR DESCRIPTION
- New action allows the parent window to dispatch an action to PIGI to hide the credit card payment option.
- Tested manually.

[INTER-3590]

[INTER-3590]: https://boldapps.atlassian.net/browse/INTER-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ