### PR TITLE
META-189: initialize Using simple order response

### DIFF
--- a/src/initialize/initialize.ts
+++ b/src/initialize/initialize.ts
@@ -9,6 +9,7 @@ import {
     setPublicOrderId,
     setShopIdentifier,
     checkApiResponse,
+    IInitializeSimpleOrderResponse,
 } from 'src';
 
 /**
@@ -20,12 +21,12 @@ import {
  * @param shopIdentifier Identification for the shop in which the order is on
  * @param environment Set the environment where the library will be working on.
  */
-export async function initialize(initData: IInitializeOrderResponse, shopIdentifier: string, environment: IEnvironment): Promise<IApiReturnObject> {
+export async function initialize(initData: IInitializeOrderResponse | IInitializeSimpleOrderResponse, shopIdentifier: string, environment: IEnvironment): Promise<IApiReturnObject> {
     const {jwt_token: jwt, public_order_id: publicOrderId} = initData;
     const returnObject = {...baseReturnObject};
     returnObject.success = true;
     returnObject.response = initData;
-    const keysToCheck = [keysToTestFromResponse.applicationState, keysToTestFromResponse.initial_data, keysToTestFromResponse.jwt_token, keysToTestFromResponse.public_order_id];
+    const keysToCheck = [keysToTestFromResponse.jwt_token, keysToTestFromResponse.public_order_id];
     const returnValue = checkApiResponse(returnObject, keysToCheck);
     if(!returnValue.success) {
         return returnValue;

--- a/src/types/apiInterfaces.ts
+++ b/src/types/apiInterfaces.ts
@@ -14,6 +14,7 @@ export interface IApiSuccessResponse {
         IDeleteDiscountResponse |
         IGetPaymentIframeUrl |
         IInitializeOrderResponse |
+        IInitializeSimpleOrderResponse |
         ICssStylingPaymentIframeResponse |
         ICheckInventoryResponse |
         IAddPaymentResponse |
@@ -120,7 +121,7 @@ export interface IApiReturnObject {
     status: number;
     success: boolean;
     error: null | IFetchError;
-    response: null | IApiResponse | IApiBatchResponse;
+    response: null | IApiResponse | IApiBatchResponse | IInitializeSimpleOrderResponse;
 }
 
 export interface IFetchCallback extends Function {
@@ -132,6 +133,12 @@ export interface IInitializeOrderResponse {
     application_state: IApplicationState,
     jwt_token: string,
     public_order_id: string
+}
+
+export interface IInitializeSimpleOrderResponse {
+    flow_settings: Record<string, unknown>;
+    jwt_token: string;
+    public_order_id: string;
 }
 
 export interface ICssStylingPaymentIframeResponse {


### PR DESCRIPTION
The new Fast Checkout endpoint provide a simple order response that can be used to initilize Frontend library with these changes.