### PR TITLE
Fix not loading alternative payments due to simple order changes

### DIFF
--- a/src/initialize/initialize.ts
+++ b/src/initialize/initialize.ts
@@ -26,7 +26,12 @@ export async function initialize(initData: IInitializeOrderResponse | IInitializ
     const returnObject = {...baseReturnObject};
     returnObject.success = true;
     returnObject.response = initData;
-    const keysToCheck = [keysToTestFromResponse.jwt_token, keysToTestFromResponse.public_order_id];
+    let keysToCheck = [keysToTestFromResponse.applicationState, keysToTestFromResponse.initial_data, keysToTestFromResponse.jwt_token, keysToTestFromResponse.public_order_id];
+
+    if (!('initial_data' in initData)) {
+        keysToCheck = [keysToTestFromResponse.jwt_token, keysToTestFromResponse.public_order_id];
+    }
+
     const returnValue = checkApiResponse(returnObject, keysToCheck);
     if(!returnValue.success) {
         return returnValue;

--- a/tests/initialize/initialize.test.ts
+++ b/tests/initialize/initialize.test.ts
@@ -1,4 +1,13 @@
-import {environmentTypes, apiErrors, baseReturnObject, initialize, IApiReturnObject, IFetchError, FetchError} from 'src';
+import {
+    environmentTypes,
+    apiErrors,
+    baseReturnObject,
+    initialize,
+    IApiReturnObject,
+    IFetchError,
+    FetchError,
+    IInitializeSimpleOrderResponse
+} from 'src';
 import {initializeOrderResponseMock} from 'src/variables/mocks';
 import * as checkApiResponse from 'src/utils/apiResponse';
 
@@ -25,6 +34,17 @@ describe('testing initialize function', () => {
     test('successful initialize', async () => {
         checkApiResponseSpy.mockReturnValueOnce(successReturn);
         const response = await initialize(initData, 'shopIdentifier', { type: environmentTypes.staging });
+
+        expect((response as IApiReturnObject).success).toBe(true);
+        expect((response as IApiReturnObject).error).toBeNull();
+        expect((response as IApiReturnObject).response).toEqual(successReturn.response);
+        expect(checkApiResponseSpy).toHaveBeenCalledTimes(timesCalled);
+    });
+
+    test('successful initialize with simple order', async () => {
+        const simpleOrder: IInitializeSimpleOrderResponse = {jwt_token: initData.jwt_token, public_order_id: initData.public_order_id, flow_settings: initData.initial_data.flow_settings};
+        checkApiResponseSpy.mockReturnValueOnce(successReturn);
+        const response = await initialize(simpleOrder, 'shopIdentifier', { type: environmentTypes.staging });
 
         expect((response as IApiReturnObject).success).toBe(true);
         expect((response as IApiReturnObject).error).toBeNull();


### PR DESCRIPTION
The `checkApiResponse` does the internal Frontend library update of the state, by removing the `application_state` and `initial_data` from that functionality we lose the state of the alternative payment gateways. This is fixining to still update the state when we have a normal order.